### PR TITLE
Fix lettura attributi tipo DateTime

### DIFF
--- a/SPID.AspNetCore.Authentication/SPID.AspNetCore.Authentication/Saml/SamlTypesExtensions.cs
+++ b/SPID.AspNetCore.Authentication/SPID.AspNetCore.Authentication/Saml/SamlTypesExtensions.cs
@@ -27,6 +27,7 @@ namespace SPID.AspNetCore.Authentication.Saml
             {
                 string stringResult => stringResult,
                 XmlNode[] xmlNodeResult => xmlNodeResult?.FirstOrDefault()?.Value,
+                DateTime dateTimeResult => dateTimeResult.ToString("yyyy-MM-dd"),
                 _ => null,
             };
 


### PR DESCRIPTION
Gli attributi nella risposta SAML di tipo DateTime (es. data di nascita) non venivano letti e risultavano nulli nei claims dell'identity.