### PR TITLE
Aggiunto attributo 'ProtocolBinding' nell'oggetto 'AuthnRequest' della richiesta SAML

### DIFF
--- a/src/SPID.AspNetCore.Authentication/Saml/SamlHandler.cs
+++ b/src/SPID.AspNetCore.Authentication/Saml/SamlHandler.cs
@@ -81,6 +81,7 @@ namespace SPID.AspNetCore.Authentication.Saml
                 Version = SamlConst.Version,
                 IssueInstant = now.AddMinutes(nowDelta).ToString(dateTimeFormat),
                 Destination = identityProvider.GetSingleSignOnServiceUrl(requestMethod),
+                ProtocolBinding = requestMethod == RequestMethod.Post ? SamlConst.ProtocolBindingPOST : SamlConst.ProtocolBindingRedirect,
                 ForceAuthn = true,
                 ForceAuthnSpecified = true,
                 Issuer = new NameIDType


### PR DESCRIPTION
Durante il processo di certificazione con Agid, ci è stato segnalato che nella richiesta SAML che viene effettuata dal nostro servizio è assente l'attributo "ProtocolBinding".

La modifica proposta valorizzerebbe l'attributo automaticamente in base al "RequestMethod" che il servizio chiamante effettua.